### PR TITLE
Fix disabling prettier

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -183,21 +183,21 @@
                         ${projectConfig.testCommand}
                         mkdir $out
                       '';
-                    "${name}-prettier" = lib.mkIf projectConfig.prettier (pkgs.runCommand
-                      "${name}-prettier"
-                      {
-                        buildInputs = [
-                          pkgs.nodePackages.prettier
-                          pkgs.coreutils
-                        ];
-                      }
-                      ''
-                        find ${projectConfig.src} -regex '.*\.\(js\|jsx\|ts\|tsx\)' |
-                          xargs prettier --check
-                        mkdir $out
-                      ''
-                    );
-                  })
+                  } // (if projectConfig.prettier then {
+                  "${name}-prettier" = pkgs.runCommand
+                    "${name}-prettier"
+                    {
+                      buildInputs = [
+                        pkgs.nodePackages.prettier
+                        pkgs.coreutils
+                      ];
+                    }
+                    ''
+                      find ${projectConfig.src} -regex '.*\.\(js\|jsx\|ts\|tsx\)' |
+                        xargs prettier --check
+                      mkdir $out
+                    '';
+                } else { }))
                 { }
                 config.nodejs;
 


### PR DESCRIPTION
Since using `lazyAttrsOf` in `garnix-lib`, `mkIf` doesn't work as expected anymore. So before this PR, when `prettier` checks are *disabled*, `nix flake show` blows up. This PR just avoids using `mkIf` to fix it.

It's a bit sad, since this is a pretty bad footgun when writing modules.

See https://github.com/garnix-io/garnix-lib/pull/14 and https://nixos.org/manual/nixos/stable/#sec-option-types-composed, in the warning on `lazyAttrsOf`.

cc: @alexdavid