### PR TITLE
Remove nixpkgs input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,7 +2,9 @@
   "nodes": {
     "dream2nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "purescript-overlay": "purescript-overlay",
         "pyproject-nix": "pyproject-nix"
       },
@@ -94,7 +96,8 @@
     },
     "root": {
       "inputs": {
-        "dream2nix": "dream2nix"
+        "dream2nix": "dream2nix",
+        "nixpkgs": "nixpkgs"
       }
     },
     "slimlock": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,9 +2,7 @@
   "nodes": {
     "dream2nix": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
+        "nixpkgs": "nixpkgs",
         "purescript-overlay": "purescript-overlay",
         "pyproject-nix": "pyproject-nix"
       },
@@ -96,8 +94,7 @@
     },
     "root": {
       "inputs": {
-        "dream2nix": "dream2nix",
-        "nixpkgs": "nixpkgs"
+        "dream2nix": "dream2nix"
       }
     },
     "slimlock": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,88 +9,105 @@
 
   inputs.dream2nix.url = "github:jkarni/dream2nix";
   outputs =
-    { self
-    , dream2nix
-    ,
+    {
+      self,
+      dream2nix,
     }:
     {
-      garnixModules.default = { pkgs, lib, config, ... }:
-    let
+      garnixModules.default =
+        {
+          pkgs,
+          lib,
+          config,
+          ...
+        }:
+        let
 
+          webServerSubmodule.options = {
+            command =
+              lib.mkOption {
+                type = lib.types.nonEmptyStr;
+                description = "The command to run to start the server in production.";
+                example = "server --port \"$PORT\"";
+              }
+              // {
+                name = "server command";
+              };
 
-      webServerSubmodule.options = {
-        command = lib.mkOption
-          {
-            type = lib.types.nonEmptyStr;
-            description = "The command to run to start the server in production.";
-            example = "server --port \"$PORT\"";
-          } // { name = "server command"; };
+            port = lib.mkOption {
+              type = lib.types.port;
+              description = "Port to forward incoming HTTP requests to. The server command has to listen on this port. This also sets the PORT environment variable for the server command.";
+              default = 3000;
+            };
 
-        port = lib.mkOption {
-          type = lib.types.port;
-          description = "Port to forward incoming HTTP requests to. The server command has to listen on this port. This also sets the PORT environment variable for the server command.";
-          default = 3000;
-        };
+            path =
+              lib.mkOption {
+                type = lib.types.nonEmptyStr;
+                description = "Path your NodeJS server will be hosted on.";
+                default = "/";
+              }
+              // {
+                name = "API path";
+              };
+          };
 
-        path = lib.mkOption
-          {
-            type = lib.types.nonEmptyStr;
-            description = "Path your NodeJS server will be hosted on.";
-            default = "/";
-          } // { name = "API path"; };
-      };
+          nodejsSubmodule.options = {
+            src =
+              lib.mkOption {
+                type = lib.types.path;
+                description = "A path to the directory containing `package.json`, `package.lock`, and `src`.";
+                example = "./.";
+              }
+              // {
+                name = "source directory";
+              };
 
-      nodejsSubmodule.options = {
-        src = lib.mkOption
-          {
-            type = lib.types.path;
-            description = "A path to the directory containing `package.json`, `package.lock`, and `src`.";
-            example = "./.";
-          } // { name = "source directory"; };
+            prettier = lib.mkOption {
+              type = lib.types.bool;
+              description = "Whether to create a CI check with prettier, and add it to the devshells.";
+              default = false;
+            };
 
-        prettier = lib.mkOption {
-          type = lib.types.bool;
-          description = "Whether to create a CI check with prettier, and add it to the devshells.";
-          default = false;
-        };
+            devTools =
+              lib.mkOption {
+                type = lib.types.listOf lib.types.package;
+                description = "A list of packages make available in the devshell for this project. This is useful for things like LSPs, formatters, etc.";
+                default = [ ];
+              }
+              // {
+                name = "development tools";
+              };
 
-        devTools = lib.mkOption
-          {
-            type = lib.types.listOf lib.types.package;
-            description = "A list of packages make available in the devshell for this project. This is useful for things like LSPs, formatters, etc.";
-            default = [ ];
-          } // { name = "development tools"; };
+            buildDependencies = lib.mkOption {
+              type = lib.types.listOf lib.types.package;
+              description = "A list of dependencies required to build this package. They are made available in the devshell, and at build time.";
+              default = [ ];
+            };
 
-        buildDependencies = lib.mkOption {
-          type = lib.types.listOf lib.types.package;
-          description = "A list of dependencies required to build this package. They are made available in the devshell, and at build time.";
-          default = [ ];
-        };
+            runtimeDependencies = lib.mkOption {
+              type = lib.types.listOf lib.types.package;
+              description = "A list of dependencies required at runtime. They are made available in the devshell, at build time, and are available on the server at runtime.";
+              default = [ ];
+            };
 
-        runtimeDependencies = lib.mkOption {
-          type = lib.types.listOf lib.types.package;
-          description = "A list of dependencies required at runtime. They are made available in the devshell, at build time, and are available on the server at runtime.";
-          default = [ ];
-        };
+            testCommand = lib.mkOption {
+              type = lib.types.str;
+              description = "The command to run the test.";
+              default = "npm run test";
+            };
 
-        testCommand = lib.mkOption {
-          type = lib.types.str;
-          description = "The command to run the test.";
-          default = "npm run test";
-        };
+            webServer = lib.mkOption {
+              type = lib.types.nullOr (lib.types.submodule webServerSubmodule);
+              description = "Whether to build a server configuration based on this project and deploy it to the garnix cloud.";
+              default = null;
+            };
 
-        webServer = lib.mkOption {
-          type = lib.types.nullOr (lib.types.submodule webServerSubmodule);
-          description = "Whether to build a server configuration based on this project and deploy it to the garnix cloud.";
-          default = null;
-        };
+          };
 
-      };
-
-      hasAnyWebServer =
-        builtins.any (projectConfig: projectConfig.webServer != null)
-          (builtins.attrValues config.nodejs);
-    in
+          hasAnyWebServer = builtins.any (projectConfig: projectConfig.webServer != null) (
+            builtins.attrValues config.nodejs
+          );
+        in
         {
           options = {
             nodejs = lib.mkOption {
@@ -101,11 +118,13 @@
 
           config =
             let
-              theModule = projectConfig:
-                { lib
-                , config
-                , dream2nix
-                , ...
+              theModule =
+                projectConfig:
+                {
+                  lib,
+                  config,
+                  dream2nix,
+                  ...
                 }:
                 {
                   imports = [
@@ -118,13 +137,14 @@
                     buildInputs = projectConfig.buildDependencies;
                   };
 
-                  deps = { nixpkgs, ... }: {
-                    inherit
-                      (nixpkgs)
-                      fetchFromGitHub
-                      stdenv
-                      ;
-                  };
+                  deps =
+                    { nixpkgs, ... }:
+                    {
+                      inherit (nixpkgs)
+                        fetchFromGitHub
+                        stdenv
+                        ;
+                    };
 
                   nodejs-package-lock-v3 = {
                     packageLockFile = "${config.mkDerivation.src}/package-lock.json";
@@ -139,21 +159,21 @@
                 };
             in
             rec {
-              packages = builtins.mapAttrs
-                (name: projectConfig:
-                  dream2nix.lib.evalModules {
-                    packageSets.nixpkgs = pkgs;
-                    modules = [
-                      (theModule projectConfig)
-                    ];
-                  }
-                )
-                config.nodejs;
-              checks = lib.foldlAttrs
-                (acc: name: projectConfig: acc //
-                  {
-                    "${name}-test" = pkgs.runCommand
-                      "${name}-test"
+              packages = builtins.mapAttrs (
+                name: projectConfig:
+                dream2nix.lib.evalModules {
+                  packageSets.nixpkgs = pkgs;
+                  modules = [
+                    (theModule projectConfig)
+                  ];
+                }
+              ) config.nodejs;
+              checks = lib.foldlAttrs (
+                acc: name: projectConfig:
+                acc
+                // {
+                  "${name}-test" =
+                    pkgs.runCommand "${name}-test"
                       {
                         buildInputs = [
                           pkgs.nodejs
@@ -174,91 +194,102 @@
                         ${projectConfig.testCommand}
                         mkdir $out
                       '';
-                  } // (if projectConfig.prettier then {
-                  "${name}-prettier" = pkgs.runCommand
-                    "${name}-prettier"
+                }
+                // (
+                  if projectConfig.prettier then
                     {
-                      buildInputs = [
-                        pkgs.nodePackages.prettier
-                        pkgs.coreutils
-                      ];
+                      "${name}-prettier" =
+                        pkgs.runCommand "${name}-prettier"
+                          {
+                            buildInputs = [
+                              pkgs.nodePackages.prettier
+                              pkgs.coreutils
+                            ];
+                          }
+                          ''
+                            find ${projectConfig.src} -regex '.*\.\(js\|jsx\|ts\|tsx\)' |
+                              xargs prettier --check
+                            mkdir $out
+                          '';
                     }
-                    ''
-                      find ${projectConfig.src} -regex '.*\.\(js\|jsx\|ts\|tsx\)' |
-                        xargs prettier --check
-                      mkdir $out
-                    '';
-                } else { }))
-                { }
-                config.nodejs;
-
-              devShells = builtins.mapAttrs
-                (name: projectConfig:
-                  pkgs.mkShell {
-                    inputsFrom = [ packages."${name}" ];
-                    packages =
-                      [ pkgs.nodejs ] ++
-                      projectConfig.devTools ++
-                      projectConfig.buildDependencies ++
-                      projectConfig.runtimeDependencies ++
-                      (if projectConfig.prettier then [ pkgs.nodePackages.prettier ] else [ ])
-                    ;
-                  }
+                  else
+                    { }
                 )
-                config.nodejs;
+              ) { } config.nodejs;
 
+              devShells = builtins.mapAttrs (
+                name: projectConfig:
+                pkgs.mkShell {
+                  inputsFrom = [ packages."${name}" ];
+                  packages =
+                    [ pkgs.nodejs ]
+                    ++ projectConfig.devTools
+                    ++ projectConfig.buildDependencies
+                    ++ projectConfig.runtimeDependencies
+                    ++ (if projectConfig.prettier then [ pkgs.nodePackages.prettier ] else [ ]);
+                }
+              ) config.nodejs;
 
               nixosConfigurations = lib.mkIf hasAnyWebServer {
                 default =
                   # Global NixOS configuration
-                  [{
-                    services.nginx = {
-                      enable = true;
-                      recommendedProxySettings = true;
-                      recommendedOptimisation = true;
-                      virtualHosts.default = {
-                        default = true;
+                  [
+                    {
+                      services.nginx = {
+                        enable = true;
+                        recommendedProxySettings = true;
+                        recommendedOptimisation = true;
+                        virtualHosts.default = {
+                          default = true;
+                        };
                       };
-                    };
 
-                    networking.firewall.allowedTCPPorts = [ 80 ];
-                  }]
+                      networking.firewall.allowedTCPPorts = [ 80 ];
+                    }
+                  ]
                   ++
                   # Per project NixOS configuration
-                  builtins.attrValues (builtins.mapAttrs
-                    (name: projectConfig: lib.mkIf (projectConfig.webServer != null) {
-                      environment.systemPackages = [ pkgs.nodejs ] ++
-                      projectConfig.runtimeDependencies;
+                  builtins.attrValues (
+                    builtins.mapAttrs (
+                      name: projectConfig:
+                      lib.mkIf (projectConfig.webServer != null) {
+                        environment.systemPackages = [ pkgs.nodejs ] ++ projectConfig.runtimeDependencies;
 
-                      systemd.services.${name} =
-                        let stateDirectoryBase = "${name}-nodejs-app/";
-                        in {
-                          description = "${name} NodeJS garnix module";
-                          wantedBy = [ "multi-user.target" ];
-                          after = [ "network-online.target" ];
-                          wants = [ "network-online.target" ];
-                          environment.PORT = toString projectConfig.webServer.port;
-                          serviceConfig = {
-                            Type = "simple";
-                            User = "nobody";
-                            Group = "nobody";
-                            StateDirectory = stateDirectoryBase;
-                            WorkingDirectory = "${packages."${name}"}/lib/node_modules/nodejs-app/";
-                            ExecStart = lib.getExe (pkgs.writeShellApplication {
-                              name = "start-${name}";
-                              runtimeInputs = [
-                                pkgs.nodejs
-                                pkgs.bash
-                                config.packages.${name}
-                              ] ++ projectConfig.runtimeDependencies;
-                              text = projectConfig.webServer.command;
-                            });
+                        systemd.services.${name} =
+                          let
+                            stateDirectoryBase = "${name}-nodejs-app/";
+                          in
+                          {
+                            description = "${name} NodeJS garnix module";
+                            wantedBy = [ "multi-user.target" ];
+                            after = [ "network-online.target" ];
+                            wants = [ "network-online.target" ];
+                            environment.PORT = toString projectConfig.webServer.port;
+                            serviceConfig = {
+                              Type = "simple";
+                              User = "nobody";
+                              Group = "nobody";
+                              StateDirectory = stateDirectoryBase;
+                              WorkingDirectory = "${packages."${name}"}/lib/node_modules/nodejs-app/";
+                              ExecStart = lib.getExe (
+                                pkgs.writeShellApplication {
+                                  name = "start-${name}";
+                                  runtimeInputs = [
+                                    pkgs.nodejs
+                                    pkgs.bash
+                                    config.packages.${name}
+                                  ] ++ projectConfig.runtimeDependencies;
+                                  text = projectConfig.webServer.command;
+                                }
+                              );
+                            };
                           };
-                        };
 
-                      services.nginx.virtualHosts.default.locations.${projectConfig.webServer.path}.proxyPass = "http://localhost:${toString projectConfig.webServer.port}";
-                    })
-                    config.nodejs);
+                        services.nginx.virtualHosts.default.locations.${projectConfig.webServer.path}.proxyPass =
+                          "http://localhost:${toString projectConfig.webServer.port}";
+                      }
+                    ) config.nodejs
+                  );
               };
             };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -7,21 +7,15 @@
     [Documentation](https://garnix.io/docs/modules/nodejs) - [Source](https://github.com/garnix-io/nodejs-module).
   '';
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
-  inputs.dream2nix = {
-    url = "github:jkarni/dream2nix";
-    inputs.nixpkgs.follows = "nixpkgs";
-  };
-
-
+  inputs.dream2nix.url = "github:jkarni/dream2nix";
   outputs =
     { self
     , dream2nix
-    , nixpkgs
     ,
     }:
+    {
+      garnixModules.default = { pkgs, lib, config, ... }:
     let
-      lib = nixpkgs.lib;
 
 
       webServerSubmodule.options = {
@@ -92,14 +86,11 @@
         };
 
       };
+
+      hasAnyWebServer =
+        builtins.any (projectConfig: projectConfig.webServer != null)
+          (builtins.attrValues config.nodejs);
     in
-    {
-      garnixModules.default = { pkgs, config, ... }:
-        let
-          hasAnyWebServer =
-            builtins.any (projectConfig: projectConfig.webServer != null)
-              (builtins.attrValues config.nodejs);
-        in
         {
           options = {
             nodejs = lib.mkOption {
@@ -273,4 +264,3 @@
         };
     };
 }
-

--- a/flake.nix
+++ b/flake.nix
@@ -7,12 +7,14 @@
     [Documentation](https://garnix.io/docs/modules/nodejs) - [Source](https://github.com/garnix-io/nodejs-module).
   '';
 
-  inputs.dream2nix.url = "github:jkarni/dream2nix";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  inputs.dream2nix = {
+    url = "github:jkarni/dream2nix";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+
   outputs =
-    {
-      self,
-      dream2nix,
-    }:
+    { dream2nix, ... }:
     {
       garnixModules.default =
         {


### PR DESCRIPTION
The `nixpkgs` dependency was only being used for library functions, and
these functions are only needed within `garnixModules.default` which
receives `lib` from `garnix-lib`. By removing the `nixpkgs` input we can
be assured that there is only one `nixpkgs` being used: the one passed
in from `garnix-lib`.

One note that differs with the `nodejs-module`: the `dream2nix`
input needs a `nixpkgs` flake input so there still may be a discrepancy
here. However, as far as I can tell, this will only affect what NodeJS
will be used, all of the NixOS configuration will be based on the
`nixpkgs` provided by `garnix-lib`. That being said, do we still want an
unused `nixpkgs` input for this module so that downstream users can easily
use `inputs.nodejs-module.inputs.nixpkgs.follows` to change the `nixpkgs`
version providing NodeJS?